### PR TITLE
Handle CNAME records pointing nowhere

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -45,3 +45,8 @@ test('concurrent resolves', async () => {
     expect(res.every((v) => v === first)).toBeTruthy();
   }
 }, 10000);
+
+test('Proper error on CNAME pointing to nowhere', async () => {
+  const p = dnsResolve('dns-cached-resolve-test.zeit.rocks');
+  await expect(p).rejects.toThrow('queryA ENOTFOUND dns-cached-resolve-test.zeit.rocks');
+}, 10000);


### PR DESCRIPTION
If a DNS name resolves to a CNAME that points to a non-existing
name then `resolve()` will return an empty array instead of
throwing an error. We should handle this by throwing a proper
error.